### PR TITLE
android-measure-source: hash hashes of individual files...

### DIFF
--- a/modules/android-build-env.nix
+++ b/modules/android-build-env.nix
@@ -215,7 +215,13 @@
         done
 
         cd $SOURCE_DIR
-        repo forall -c 'echo $REPO_PATH $(git rev-parse HEAD^{tree})' | sort | sha256sum | cut -d ' ' -f 1
+
+        repo forall -c '
+          git ls-files | while read file
+          do
+            echo "$(sha256sum "$file")"
+          done
+        ' | sort | sha256sum
       '';
 
     in


### PR DESCRIPTION
instead of reusing git's merkle tree. It's slower, but an explicit downstream requirement