### PR TITLE
Small fixes

### DIFF
--- a/modules/fatal-error.nix
+++ b/modules/fatal-error.nix
@@ -43,7 +43,13 @@ let
         Restart = "no";
       };
 
+      environment = {
+        TERM = "linux";
+        TERMINFO = "${pkgs.ncurses}/share/terminfo";
+      };
+
       path = [
+        pkgs.coreutils
         pkgs.dialog
         pkgs.kbd
         pkgs.systemd
@@ -73,6 +79,7 @@ in
   boot.initrd.systemd = {
     inherit targets services;
     extraBin = {
+      cat = "${pkgs.coreutils}/bin/cat";
       dialog = "${pkgs.dialog}/bin/dialog";
       chvt = "${pkgs.kbd}/bin/chvt";
     };

--- a/modules/image.nix
+++ b/modules/image.nix
@@ -319,8 +319,6 @@
               "systemd-cryptsetup@var_lib_keylime_crypt.service"
               "systemd-cryptsetup@var_lib_crypt.service"
             ];
-            after = [ "systemd-udev-settle.service" ];
-            requires = [ "systemd-udev-settle.service" ];
             serviceConfig.ExecStartPost = waitForDisk;
           };
 

--- a/modules/image.nix
+++ b/modules/image.nix
@@ -304,6 +304,9 @@
         # Run systemd-repart in initrd at boot
         repart = {
           enable = true;
+          # We disable discard as it can make boots painfully slow here on some
+          # of our test machines
+          discard = lib.mkDefault false;
           extraArgs = [
             "--key-file=/etc/disk.key"
             # --factory-reset instructs systemd-repart to reset all partitions marked with FactoryReset=true,

--- a/modules/secure-boot.nix
+++ b/modules/secure-boot.nix
@@ -30,13 +30,13 @@ let
     sb_status="$(bootctl 2>/dev/null \
     | awk '/Secure Boot:/ {print $3 " " $4}')"
 
-    if [ "$sb_status" = "disabled (setup)" ]
+    if [ "$sb_status" = "disabled (setup)" ] || [ "$sb_status" = "disabled (audit)" ]
     then
       echo "Secure Boot in Setup Mode, enrolling" | systemd-cat -p info
       ${lib.getExe enroll-secure-boot}
       echo "enrolled. Rebooting..." | systemd-cat -p info
       systemctl --no-block reboot
-    elif [ "$sb_status" = "enabled (user)" ]
+    elif [ "$sb_status" = "enabled (user)" ] || [ "$sb_status" = "enabled (deployed)" ]
     then
       echo "Secure Boot active" | systemd-cat -p info
     else


### PR DESCRIPTION
* [secure-boot: support audit & deployed modes as well](https://github.com/phaer/nixos-android-builder/commit/3b67ee400240921321a2cb539507b7b9b98b858c)
* [fatal-error: add cat & terminfo to initrd again](https://github.com/phaer/nixos-android-builder/commit/a4be90b5c99fa4af131ea4d59e968ec986fa0e72)
* [image: drop udev-settle dependency from systemd-repart](https://github.com/phaer/nixos-android-builder/commit/2ccbf35d42fe561d9c8e18618f320032bcaefdd2)
* [image: disable initrd repart discard for boot-time factory reset](https://github.com/phaer/nixos-android-builder/commit/88c52eace40fcf5f59d7768675172a86b9126f7d)