### PR TITLE
Add REUSE license metadata

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 use flake

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: Format check 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 android-builder.qcow2
 android-builder-efi-vars.fd
 *.raw

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,185 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
+writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to You under this License for that Work shall terminate as of
+the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+  (a) You must give any other recipients of the Work or Derivative Works a copy
+  of this License; and
+
+  (b) You must cause any modified files to carry prominent notices stating that
+  You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works that You
+  distribute, all copyright, patent, trademark, and attribution notices from
+  the Source form of the Work, excluding those notices that do not pertain to
+  any part of the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its distribution,
+  then any Derivative Works that You distribute must include a readable copy of
+  the attribution notices contained within such NOTICE file, excluding those
+  notices that do not pertain to any part of the Derivative Works, in at least
+  one of the following places: within a NOTICE text file distributed as part of
+  the Derivative Works; within the Source form or documentation, if provided
+  along with the Derivative Works; or, within a display generated by the
+  Derivative Works, if and wherever such third-party notices normally appear.
+
+The contents of the NOTICE file are for informational purposes only and do not
+modify the License. You may add Your own attribution notices within Derivative
+Works that You distribute, alongside or as an addendum to the NOTICE text from
+the Work, provided that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein
+shall supersede or modify the terms of any separate license agreement you may
+have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC-BY-SA-4.0.txt
+++ b/LICENSES/CC-BY-SA-4.0.txt
@@ -1,0 +1,374 @@
+Attribution-ShareAlike 4.0 International
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and does
+not provide legal services or legal advice. Distribution of Creative Commons
+public licenses does not create a lawyer-client or other relationship.
+Creative Commons makes its licenses and related information available on an
+"as-is" basis.
+
+Creative Commons gives no warranties regarding its licenses, any material
+licensed under their terms and conditions, or any related information.
+Creative Commons disclaims all liability for damages resulting from their use
+to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share original
+works of authorship and other material subject to copyright and certain other
+rights specified in the public license below. The following considerations are
+for informational purposes only, are not exhaustive, and do not form part of
+our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by
+those authorized to give the public permission to use material in ways
+otherwise restricted by copyright and certain other rights. Our licenses are
+irrevocable. Licensors should read and understand the terms and conditions of
+the license they choose before applying it. Licensors should also secure all
+rights necessary before applying our licenses so that the public can reuse the
+material as expected.
+
+Licensors should clearly mark any material not subject to the license. This
+includes other CC-licensed material, or material used under an exception or
+limitation to copyright. More considerations for licensors:
+wiki.creativecommons.org/Considerations_for_licensors
+
+Considerations for the public: By using one of our public licenses, a licensor
+grants the public permission to use the licensed material under specified
+terms and conditions.
+
+If the licensor's permission is not necessary for any reason - for example,
+because of any applicable exception or limitation to copyright - then that use
+is not regulated by the license. Our licenses grant only permissions under
+copyright and certain other rights that a licensor has authority to grant. Use
+of the licensed material may still be restricted for other reasons, including
+because others have copyright or other rights in the material.
+
+A licensor may make special requests, such as asking that all changes be marked
+or described. Although not required by our licenses, you are encouraged to
+respect those requests where reasonable.
+
+More considerations for the public:
+wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be
+bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public License").
+To the extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of these terms
+and conditions, and the Licensor grants You such rights in consideration of
+benefits the Licensor receives from making the Licensed Material available
+under these terms and conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar Rights that
+is derived from or based upon the Licensed Material and in which the Licensed
+Material is translated, altered, arranged, transformed, or otherwise modified
+in a manner requiring permission under the Copyright and Similar Rights held
+by the Licensor.
+
+For purposes of this Public License, where the Licensed Material is a musical
+work, performance, or sound recording, Adapted Material is always produced
+where the Licensed Material is synched in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright and Similar
+Rights in Your contributions to Adapted Material in accordance with the terms
+and conditions of this Public License.
+
+c. BY-SA Compatible License means a license listed at
+creativecommons.org/compatiblelicenses, approved by Creative Commons as
+essentially the equivalent of this Public License.
+
+d. Copyright and Similar Rights means copyright and/or similar rights closely
+related to copyright including, without limitation, performance, broadcast,
+sound recording, and Sui Generis Database Rights, without regard to how the
+rights are labeled or categorized.
+
+For purposes of this Public License, the rights specified in Section 2(b)(1)-(2)
+are not Copyright and Similar Rights.
+
+e. Effective Technological Measures means those measures that, in the absence
+of proper authority, may not be circumvented under laws fulfilling obligations
+under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996,
+and/or similar international agreements.
+
+f. Exceptions and Limitations means fair use, fair dealing, and/or any other
+exception or limitation to Copyright and Similar Rights that applies to Your
+use of the Licensed Material.
+
+g. License Elements means the license attributes listed in the name of a
+Creative Commons Public License. The License Elements of this Public License
+are Attribution and ShareAlike.
+
+h. Licensed Material means the artistic or literary work, database, or other
+material to which the Licensor applied this Public License.
+
+i. Licensed Rights means the rights granted to You subject to the terms and
+conditions of this Public License, which are limited to all Copyright and
+Similar Rights that apply to Your use of the Licensed Material and that the
+Licensor has authority to license.
+
+j. Licensor means the individual(s) or entity(ies) granting rights under this
+Public License.
+
+k. Share means to provide material to the public by any means or process that
+requires permission under the Licensed Rights, such as reproduction, public
+display, public performance, distribution, dissemination, communication, or
+importation, and to make material available to the public including in ways
+that members of the public may access the material from a place and at a time
+individually chosen by them.
+
+l. Sui Generis Database Rights means rights other than copyright resulting
+from Directive 96/9/EC of the European Parliament and of the Council of 11
+March 1996 on the legal protection of databases, as amended and/or succeeded,
+as well as other essentially equivalent rights anywhere in the world.
+
+m. You means the individual or entity exercising the Licensed Rights under
+this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+
+1. Subject to the terms and conditions of this Public License, the Licensor
+hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive,
+irrevocable license to exercise the Licensed Rights in the Licensed Material
+to:
+
+  a. reproduce and Share the Licensed Material, in whole or in part; and
+
+  b. produce, reproduce, and Share Adapted Material.
+
+2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions
+and Limitations apply to Your use, this Public License does not apply, and You
+do not need to comply with its terms and conditions.
+
+3. Term. The term of this Public License is specified in Section 6(a).
+
+4. Media and formats; technical modifications allowed. The Licensor authorizes
+You to exercise the Licensed Rights in all media and formats whether now known
+or hereafter created, and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or authority to
+forbid You from making technical modifications necessary to exercise the
+Licensed Rights, including technical modifications necessary to circumvent
+Effective Technological Measures. For purposes of this Public License, simply
+making modifications authorized by this Section 2(a)(4) never produces
+Adapted Material.
+
+5. Downstream recipients.
+
+  a. Offer from the Licensor -- Licensed Material. Every recipient of the
+  Licensed Material automatically receives an offer from the Licensor to
+  exercise the Licensed Rights under the terms and conditions of this Public
+  License.
+
+  b. Additional offer from the Licensor -- Adapted Material. Every recipient
+  of Adapted Material from You automatically receives an offer from the Licensor
+  to exercise the Licensed Rights in the Adapted Material under the conditions
+  of the Adapter's License You apply.
+
+  c. No downstream restrictions. You may not offer or impose any additional or
+  different terms or conditions on, or apply any Effective Technological
+  Measures to, the Licensed Material if doing so restricts exercise of the
+  Licensed Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes or may be
+construed as permission to assert or imply that You are, or that Your use of
+the Licensed Material is, connected with, or sponsored, endorsed, or granted
+official status by, the Licensor or others designated to receive attribution
+as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+1. Moral rights, such as the right of integrity, are not licensed under this
+Public License, nor are publicity, privacy, and/or other similar personality
+rights; however, to the extent possible, the Licensor waives and/or agrees not
+to assert any such rights held by the Licensor to the limited extent necessary
+to allow You to exercise the Licensed Rights, but not otherwise.
+
+2. Patent and trademark rights are not licensed under this Public License.
+
+3. To the extent possible, the Licensor waives any right to collect royalties
+from You for the exercise of the Licensed Rights, whether directly or through
+a collecting society under any voluntary or waivable statutory or compulsory
+licensing scheme. In all other cases the Licensor expressly reserves any
+right to collect such royalties.
+
+Section 3 -- License Conditions. Your exercise of the Licensed Rights is
+expressly made subject to the following conditions.
+
+a. Attribution.
+
+1. If You Share the Licensed Material (including in modified form), You must:
+
+  a. retain the following if it is supplied by the Licensor with the Licensed
+  Material:
+
+    i. identification of the creator(s) of the Licensed Material and any others
+    designated to receive attribution, in any reasonable manner requested by
+    the Licensor (including by pseudonym if designated);
+
+    ii. a copyright notice;
+
+    iii. a notice that refers to this Public License;
+
+    iv. a notice that refers to the disclaimer of warranties;
+
+    v. a URI or hyperlink to the Licensed Material to the extent reasonably
+    practicable;
+
+  b. indicate if You modified the Licensed Material and retain an indication of
+  any previous modifications; and
+
+  c. indicate the Licensed Material is licensed under this Public License, and
+  include the text of, or the URI or hyperlink to, this Public License.
+
+2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner
+based on the medium, means, and context in which You Share the Licensed
+Material. For example, it may be reasonable to satisfy the conditions by
+providing a URI or hyperlink to a resource that includes the required
+information.
+
+3. If requested by the Licensor, You must remove any of the information
+required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+b. ShareAlike. In addition to the conditions in Section 3(a), if You Share
+Adapted Material You produce, the following conditions also apply.
+
+1. The Adapter's License You apply must be a Creative Commons license with the
+same License Elements, this version or later, or a BY-SA Compatible License.
+
+2. You must include the text of, or the URI or hyperlink to, the Adapter's
+License You apply. You may satisfy this condition in any reasonable manner
+based on the medium, means, and context in which You Share Adapted Material.
+
+3. You may not offer or impose any additional or different terms or conditions
+on, or apply any Effective Technological Measures to, Adapted Material that
+restrict exercise of the rights granted under the Adapter's License You apply.
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to
+Your use of the Licensed Material:
+
+a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract,
+reuse, reproduce, and Share all or a substantial portion of the contents of
+the database;
+
+b. if You include all or a substantial portion of the database contents in a
+database in which You have Sui Generis Database Rights, then the database in
+which You have Sui Generis Database Rights (but not its individual contents) is
+Adapted Material, including for purposes of Section 3(b); and
+
+c. You must comply with the conditions in Section 3(a) if You Share all or a
+substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace
+Your obligations under this Public License where the Licensed Rights include
+other Copyright and Similar Rights.
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE EXTENT
+POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS AND AS-AVAILABLE,
+AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE LICENSED
+MATERIAL, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES,
+WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT KNOWN OR
+DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT ALLOWED IN FULL OR IN
+PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE TO YOU ON
+ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION, NEGLIGENCE) OR OTHERWISE FOR
+ANY DIRECT, SPECIAL, INDIRECT, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY,
+OR OTHER LOSSES, COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE
+OR USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR DAMAGES. WHERE A LIMITATION OF
+LIABILITY IS NOT ALLOWED IN FULL OR IN PART, THIS LIMITATION MAY NOT APPLY TO
+YOU.
+
+c. The disclaimer of warranties and limitation of liability provided above
+shall be interpreted in a manner that, to the extent possible, most closely
+approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 -- Term and Termination.
+
+a. This Public License applies for the term of the Copyright and Similar Rights
+licensed here. However, if You fail to comply with this Public License, then
+Your rights under this Public License terminate automatically.
+
+b. Where Your right to use the Licensed Material has terminated under Section
+6(a), it reinstates:
+
+  1. automatically as of the date the violation is cured, provided it is cured
+  within 30 days of Your discovery of the violation; or
+
+  2. upon express reinstatement by the Licensor.
+
+For the avoidance of doubt, this Section 6(b) does not affect any right the
+Licensor may have to seek remedies for Your violations of this Public License.
+
+c. For the avoidance of doubt, the Licensor may also offer the Licensed
+Material under separate terms or conditions or stop distributing the Licensed
+Material at any time; however, doing so will not terminate this Public License.
+
+d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 -- Other Terms and Conditions.
+
+a. The Licensor shall not be bound by any additional or different terms or
+conditions communicated by You unless expressly agreed.
+
+b. Any arrangements, understandings, or agreements regarding the Licensed
+Material not stated herein are separate from and independent of the terms and
+conditions of this Public License.
+
+Section 8 -- Interpretation.
+
+a. For the avoidance of doubt, this Public License does not, and shall not be
+interpreted to, reduce, limit, restrict, or impose conditions on any use of
+the Licensed Material that could lawfully be made without permission under
+this Public License.
+
+b. To the extent possible, if any provision of this Public License is deemed
+unenforceable, it shall be automatically reformed to the minimum extent
+necessary to make it enforceable. If the provision cannot be reformed, it
+shall be severed from this Public License without affecting the enforceability
+of the remaining terms and conditions.
+
+c. No term or condition of this Public License will be waived and no failure to
+comply consented to unless expressly agreed to by the Licensor.
+
+d. Nothing in this Public License constitutes or may be interpreted as a
+limitation upon, or waiver of, any privileges and immunities that apply to the
+Licensor or You, including from the legal processes of any jurisdiction or
+authority.
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses. Notwithstanding,
+Creative Commons may elect to apply one of its public licenses to material it
+publishes and in those instances will be considered the "Licensor." The text
+of the Creative Commons public licenses is dedicated to the public domain
+under the CC0 Public Domain Dedication.
+
+Except for the limited purpose of indicating that material is shared under a
+Creative Commons public license or as otherwise permitted by the Creative
+Commons policies published at creativecommons.org/policies, Creative Commons
+does not authorize the use of the trademark "Creative Commons" or any other
+trademark or logo of Creative Commons without its prior written consent
+including, without limitation, in connection with any unauthorized
+modifications to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material.
+
+For the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # NixOS Android Builder
 
 This repository contains a custom Linux system to build Android Open Source Project in a (mostly) ephemeral environment. Our images, based on NixOS, provide a FHS-compatible enviroment that can run upstream Androids toolchain while being flexible and relatively easy to adapt due to the NixOS module system.
@@ -6,4 +11,3 @@ We boot into memory while keeping build state that's too big for memory in an ep
 Persistent, TPM2-bound LUKS partitions store keylime agent state and systemd-encrypted credentials across reboots. A second disk can optionally be used as "artifact storage" for build outputs in air-gapped environments.
 
 See [user-guide.md](./docs/user-guide.md) for usage guidance and [docs.md](./docs/docs.md) for a more detailed description of design considerations, used components limitations, and further work.
-

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   # Name our system. Image file names and metadata is derived from this.
   system.name = "android-builder";

--- a/desktop-configuration.nix
+++ b/desktop-configuration.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Interactive desktop configuration for building and configuring the
 # other nixosConfigurations in this repository.
 {

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 ---
 title: NixOS Android Builder
 ---
@@ -528,5 +533,4 @@ flowchart TB
 **TPM** – Trusted Platform Module. A dedicated security chip that provides hardware-based cryptographic functions and key storage.
 
 **UKI** – Unified Kernel Image. A single EFI executable containing the Linux kernel, initrd, and boot parameters, simplifying Secure Boot signing.
-
 

--- a/docs/docs.pdf.license
+++ b/docs/docs.pdf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/header.tex
+++ b/docs/header.tex
@@ -1,4 +1,7 @@
 
+% SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+% SPDX-License-Identifier: CC-BY-SA-4.0
+
 \usepackage{xcolor,fvextra}
 
 \definecolor{Light}{HTML}{F4F4F4}

--- a/docs/keylime-git-server.md
+++ b/docs/keylime-git-server.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 ---
 title: Attestation-Gated Git Server
 ---

--- a/docs/keylime-git-server.pdf.license
+++ b/docs/keylime-git-server.pdf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/keylime-server.md
+++ b/docs/keylime-server.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 ---
 title: Keylime Server Setup
 ---

--- a/docs/keylime-server.pdf.license
+++ b/docs/keylime-server.pdf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/nixos-options.lua
+++ b/docs/nixos-options.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+-- SPDX-License-Identifier: CC-BY-SA-4.0
+
 local json = require("pandoc.json")
 local utils = require("pandoc.utils")
 

--- a/docs/pygments.theme.license
+++ b/docs/pygments.theme.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 ---
 title: NixOS Android Builder User Guide
 ---

--- a/docs/user-guide.pdf.license
+++ b/docs/user-guide.pdf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   description = "An ephemeral NixOS system to build Android Open Source Project";
 

--- a/modules/android-build-env.nix
+++ b/modules/android-build-env.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   pkgs,

--- a/modules/artifact-storage.nix
+++ b/modules/artifact-storage.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Store outputs on an unencrypted, persistent disk partition
 {
   lib,

--- a/modules/artifact-storage.sh
+++ b/modules/artifact-storage.sh
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 select_disk() {

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Generic NixOS base configuration shared across all machine types.
 {
   lib,

--- a/modules/branch-selector.nix
+++ b/modules/branch-selector.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   config,

--- a/modules/builder.nix
+++ b/modules/builder.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Android-builder-specific base configuration.
 #
 # Options and defaults that only apply to the ephemeral android build

--- a/modules/credential-storage.nix
+++ b/modules/credential-storage.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Store systemd credentials on a persistent, TPM2-bound LUKS partition
 #
 # This module bind-mounts the credential directory to

--- a/modules/debug.nix
+++ b/modules/debug.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Support debug builds with interactive login & extra software.
 {
   config,

--- a/modules/desktop-image.nix
+++ b/modules/desktop-image.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Disk image and partition layout for the desktop configuration.
 #
 # Simple conventional layout:

--- a/modules/desktop-vm.nix
+++ b/modules/desktop-vm.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # VM settings for the desktop configuration.
 #
 # Provides system.build.vmWithWritableDisk which can be exposed as

--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Login greeter via greetd + tuigreet.
 #
 # Provides a minimal shell session with U2F authentication (when keys are

--- a/modules/disable-ldso.nix
+++ b/modules/disable-ldso.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 { lib, ... }:
 {
   disabledModules = [

--- a/modules/fatal-error.nix
+++ b/modules/fatal-error.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 { lib, pkgs, ... }:
 
 let

--- a/modules/fhsenv.nix
+++ b/modules/fhsenv.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   pkgs,

--- a/modules/image.nix
+++ b/modules/image.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   pkgs,
   lib,

--- a/modules/keylime-agent.nix
+++ b/modules/keylime-agent.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   config,
   lib,

--- a/modules/keylime.nix
+++ b/modules/keylime.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   config,
   lib,

--- a/modules/lib/keylime-shared.nix
+++ b/modules/lib/keylime-shared.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Shared definitions for the keylime server NixOS module (modules/keylime.nix)
 # and the system-manager port (system-manager/keylime.nix). Contains INI
 # helpers, config defaults, option declarations, and config-file generators.

--- a/modules/lib/scripts/keylime-auto-enroll.py
+++ b/modules/lib/scripts/keylime-auto-enroll.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Auto-enrollment daemon for Keylime agents.
 
 Runs an HTTPS server that accepts measured boot reports from agents and

--- a/modules/lib/scripts/keylime-generate-certs.py
+++ b/modules/lib/scripts/keylime-generate-certs.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Generate Keylime TLS PKI if not already present.
 
 Expected environment variables (set by the systemd service):

--- a/modules/lib/scripts/keylime-git-auth.py
+++ b/modules/lib/scripts/keylime-git-auth.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Auth subrequest backend for the attestation-gated git server.
 
 nginx calls GET /verify?uuid=<agent-uuid> via auth_request.

--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Enable nix with flake support, no channels.
 {
   lib,

--- a/modules/secure-boot.nix
+++ b/modules/secure-boot.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   config,
   pkgs,

--- a/modules/unattended.nix
+++ b/modules/unattended.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   config,

--- a/modules/unattended.sh
+++ b/modules/unattended.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 IFS=',' read -ra steps <<< "${STEPS}"
 total=${#steps[@]}

--- a/modules/vm.nix
+++ b/modules/vm.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Settings which should only be applied if run as a VM, not on bare metal.
 {
   lib,

--- a/modules/yubikey-auth.nix
+++ b/modules/yubikey-auth.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # To test yubikey auth in the vm, get your yubikeys product ids and then run:
 # nix run -L .\#run-vm -- -usb -device usb-host,vendorid=0x1050,productid=0x0407 -device usb-host,vendorid=0x1050,productid=0x0116
 {

--- a/packages/attestation-ctl/attestation-ctl.py
+++ b/packages/attestation-ctl/attestation-ctl.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Client-side tool for managing remote attestation agents.
 
 Reads the attestation server address and CA cert from

--- a/packages/attestation-ctl/default.nix
+++ b/packages/attestation-ctl/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   writers,
 }:

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # All custom packages, built once and passed to modules via _module.args.
 { pkgs }:
 let

--- a/packages/disk-installer/configure-disk-image.py
+++ b/packages/disk-installer/configure-disk-image.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # flake8: noqa: E501
 import sys
 import os

--- a/packages/disk-installer/default.nix
+++ b/packages/disk-installer/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   writers,

--- a/packages/disk-installer/installer-vm.nix
+++ b/packages/disk-installer/installer-vm.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   config,

--- a/packages/disk-installer/installer.nix
+++ b/packages/disk-installer/installer.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   config,

--- a/packages/disk-installer/run.sh
+++ b/packages/disk-installer/run.sh
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 ddrescue2gauge() {

--- a/packages/docs/default.nix
+++ b/packages/docs/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   writeShellApplication,

--- a/packages/fhsenv/default.nix
+++ b/packages/fhsenv/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Create an environment similar to `pkgs.buildFHSEnv`, but with a twist:
 # No symlinks to the nix store are included, `/bin` and `/lib` include regular
 # files. Executables are patched to look for their dynamic linker and libraries

--- a/packages/fhsenv/fhsenv.py
+++ b/packages/fhsenv/fhsenv.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
   Recursively copy and merge /bin and /lib from a list of store paths
   - Warn if files have already been `seen` in another store path, and list the

--- a/packages/glibc-vanilla/default.nix
+++ b/packages/glibc-vanilla/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 { glibc, linuxHeaders }:
 glibc.overrideAttrs (oldAttrs: {
   configureFlags = (oldAttrs.configureFlags or [ ]) ++ [

--- a/packages/keylime-agent/0001-push-model-cache-UEFI-event-log-bytes-at-startup.patch.license
+++ b/packages/keylime-agent/0001-push-model-cache-UEFI-event-log-bytes-at-startup.patch.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime-agent/default.nix
+++ b/packages/keylime-agent/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   rustPlatform,

--- a/packages/keylime-git-clone/default.nix
+++ b/packages/keylime-git-clone/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 { lib, pkgs }:
 
 pkgs.writeShellApplication {

--- a/packages/keylime-measured-boot-policy/README.md
+++ b/packages/keylime-measured-boot-policy/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # UKI Measured Boot Policy for Keylime
 
 Custom keylime measured boot attestation (MBA) policy for Unified Kernel

--- a/packages/keylime-measured-boot-policy/default.nix
+++ b/packages/keylime-measured-boot-policy/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Measured boot policy for keylime (UKI boot chain).
 #
 # Provides:

--- a/packages/keylime-measured-boot-policy/measured_boot_policy.py
+++ b/packages/keylime-measured-boot-policy/measured_boot_policy.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Keylime measured boot policy for UKI (Unified Kernel Image) boot.
 
 Registers a ``uki`` policy that validates SCRTM, firmware blobs,

--- a/packages/keylime-measured-boot-policy/pyproject.toml
+++ b/packages/keylime-measured-boot-policy/pyproject.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/packages/keylime-measured-boot-policy/test_measured_boot_policy.py
+++ b/packages/keylime-measured-boot-policy/test_measured_boot_policy.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for the UKI measured boot policy.
 
 Tests the policy against synthetic event logs to verify it

--- a/packages/keylime/0001-elparsing-check-tpm2_eventlog-exit-code-instead-of-s.patch.license
+++ b/packages/keylime/0001-elparsing-check-tpm2_eventlog-exit-code-instead-of-s.patch.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/0002-tpm-use-policy-s-relevant-PCRs-for-event-log-verific.patch.license
+++ b/packages/keylime/0002-tpm-use-policy-s-relevant-PCRs-for-event-log-verific.patch.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/0003-tpm_engine-bypass-dual-mapping-cache-for-uefi_ref_st.patch.license
+++ b/packages/keylime/0003-tpm_engine-bypass-dual-mapping-cache-for-uefi_ref_st.patch.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/0004-tpm_engine-bypass-dual-mapping-cache-for-accept_atte.patch.license
+++ b/packages/keylime/0004-tpm_engine-bypass-dual-mapping-cache-for-accept_atte.patch.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/default.nix
+++ b/packages/keylime/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   python3Packages,

--- a/packages/measured-boot-library/default.nix
+++ b/packages/measured-boot-library/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Shared library for parsing UEFI event logs, generating measured
 # boot reference states, PCR replay, and refstate diffing.  Used
 # by measure-boot-state, report-measured-boot-state, and

--- a/packages/measured-boot-library/measured_boot_state.py
+++ b/packages/measured-boot-library/measured_boot_state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Measured boot reference state library.
 
 Parses the binary UEFI event log (via ``tpm2_eventlog``) and

--- a/packages/measured-boot-library/pyproject.toml
+++ b/packages/measured-boot-library/pyproject.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/packages/measured-boot-library/test_measured_boot_state.py
+++ b/packages/measured-boot-library/test_measured_boot_state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for the measured boot state library.
 
 Tests refstate generation, PCR replay, and refstate diffing

--- a/packages/measured-boot-state/debug-measured-boot-state.py
+++ b/packages/measured-boot-state/debug-measured-boot-state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Debug measured boot state mismatches.
 
 Diagnoses why attestation fails by replaying the UEFI event log,

--- a/packages/measured-boot-state/default.nix
+++ b/packages/measured-boot-state/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   lib,
   efivar,

--- a/packages/measured-boot-state/measure-boot-state.py
+++ b/packages/measured-boot-state/measure-boot-state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Generate a measured boot reference state from an event log.
 
 Thin CLI wrapper around the ``measured_boot_state`` library.

--- a/packages/measured-boot-state/report-measured-boot-state.py
+++ b/packages/measured-boot-state/report-measured-boot-state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Report measured boot state to the auto-enrollment server.
 
 Generates a measured boot reference state from the UEFI

--- a/packages/secure-boot-scripts/create-signing-keys.sh
+++ b/packages/secure-boot-scripts/create-signing-keys.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 

--- a/packages/secure-boot-scripts/default.nix
+++ b/packages/secure-boot-scripts/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   writeShellApplication,
   sbsigntool,

--- a/packages/secure-boot-scripts/sign-disk-image.sh
+++ b/packages/secure-boot-scripts/sign-disk-image.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Given a read-only disk image:
 # - copy it to a temporary, writable location
 # - find its ESP partition

--- a/packages/tpm2-tools/default.nix
+++ b/packages/tpm2-tools/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # tpm2-tools from upstream master, for the PCR 11 EV_IPL fix
 # (commit b25c9220: "tpm2_eventlog: Extend pcrs using event EV_IPL")
 # which silences spurious warnings about UKI measurements in PCR 11.

--- a/system-manager/keylime.nix
+++ b/system-manager/keylime.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Keylime server (registrar + verifier) module for system-manager.
 #
 # Shares options, defaults, and config generation with modules/keylime.nix

--- a/system-manager/tpm2.nix
+++ b/system-manager/tpm2.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # TPM2 support for system-manager (non-NixOS distributions).
 #
 # This is a simplified port of the NixOS security.tpm2 module. It manages udev

--- a/tests/credential-storage.nix
+++ b/tests/credential-storage.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 { lib, ... }:
 {
   name = "credential-storage";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   self,
   pkgs,

--- a/tests/desktop-installer.nix
+++ b/tests/desktop-installer.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   desktopInstallerModules,
   payload,

--- a/tests/desktop.nix
+++ b/tests/desktop.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   self,
   desktopModules,

--- a/tests/installer-interactive.nix
+++ b/tests/installer-interactive.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   installerModules,
   payload,

--- a/tests/installer.nix
+++ b/tests/installer.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   installerModules,
   payload,

--- a/tests/integration.nix
+++ b/tests/integration.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {
   imageModules,
   customPackages,

--- a/tests/keylime-auto-enroll.nix
+++ b/tests/keylime-auto-enroll.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Test: auto-enrollment of keylime agents with measured boot policy.
 #
 # Verifies that the auto-enrollment daemon automatically enrolls a

--- a/tests/keylime-git-server.nix
+++ b/tests/keylime-git-server.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # End-to-end VM test for the attestation-gated git server.
 #
 # This uses a real keylime registrar, verifier, and agent with an

--- a/tests/keylime.nix
+++ b/tests/keylime.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Core keylime test: registration, attestation, tampered refstate
 # rejection, and push-mode timeout recovery.
 #

--- a/tests/unit-tests.nix
+++ b/tests/unit-tests.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Python unit tests for measured boot policy.
 #
 # Both measured-boot-library and keylime-measured-boot-policy run


### PR DESCRIPTION
Implemented REUSE license metadata across the repository.

  This change adds the missing SPDX copyright/license headers to tracked source files and introduces sidecar .license files
  where inline comments are not valid, including patches and generated documents. It also adds the LICENSES/ directory with
  the canonical Apache-2.0 and CC-BY-SA-4.0 texts used by the repo.

  Covered areas include:

  - Top-level Nix entry points and module files
  - Shell scripts and Python helpers
  - Docs sources, TeX/Lua support files, workflow config, and README
  - Package directories such as keylime, measured-boot-library, measured-boot-state, disk-installer, secure-boot-scripts,
    and others

  - Sidecar license files for tracked .patch files and generated docs/*.pdf artifacts

  No functional code paths were changed.

  Testing:

  - No runtime behavior change expected
  - Changes were verified by inspecting the edited file headers and the generated sidecar files
  - `nix build -L .#desktop-installer-image`
  - `nix build -L .#installer-image` 