### PR TITLE
reuse: replace sidecar licenses with REUSE.toml annotations

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,16 @@
+version = 1
+
+[[annotations]]
+path = "flake.lock"
+SPDX-FileCopyrightText = "2026 TII (SSRC) and the Ghaf contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ["docs/*.pdf", "docs/pygments.theme"]
+SPDX-FileCopyrightText = "2026 TII (SSRC) and the Ghaf contributors"
+SPDX-License-Identifier = "CC-BY-SA-4.0"
+
+[[annotations]]
+path = ["packages/keylime/*.patch", "packages/keylime-agent/*.patch"]
+SPDX-FileCopyrightText = "2026 TII (SSRC) and the Ghaf contributors"
+SPDX-License-Identifier = "Apache-2.0"

--- a/docs/docs.pdf.license
+++ b/docs/docs.pdf.license
@@ -1,2 +1,0 @@
-SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/keylime-git-server.pdf.license
+++ b/docs/keylime-git-server.pdf.license
@@ -1,2 +1,0 @@
-SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/keylime-server.pdf.license
+++ b/docs/keylime-server.pdf.license
@@ -1,2 +1,0 @@
-SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/pygments.theme.license
+++ b/docs/pygments.theme.license
@@ -1,2 +1,0 @@
-SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-SPDX-License-Identifier: CC-BY-SA-4.0

--- a/docs/user-guide.pdf.license
+++ b/docs/user-guide.pdf.license
@@ -1,2 +1,0 @@
-SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-SPDX-License-Identifier: CC-BY-SA-4.0

--- a/packages/keylime-agent/0001-push-model-cache-UEFI-event-log-bytes-at-startup.patch.license
+++ b/packages/keylime-agent/0001-push-model-cache-UEFI-event-log-bytes-at-startup.patch.license
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/0001-elparsing-check-tpm2_eventlog-exit-code-instead-of-s.patch.license
+++ b/packages/keylime/0001-elparsing-check-tpm2_eventlog-exit-code-instead-of-s.patch.license
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/0002-tpm-use-policy-s-relevant-PCRs-for-event-log-verific.patch.license
+++ b/packages/keylime/0002-tpm-use-policy-s-relevant-PCRs-for-event-log-verific.patch.license
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/0003-tpm_engine-bypass-dual-mapping-cache-for-uefi_ref_st.patch.license
+++ b/packages/keylime/0003-tpm_engine-bypass-dual-mapping-cache-for-uefi_ref_st.patch.license
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-# SPDX-License-Identifier: Apache-2.0

--- a/packages/keylime/0004-tpm_engine-bypass-dual-mapping-cache-for-accept_atte.patch.license
+++ b/packages/keylime/0004-tpm_engine-bypass-dual-mapping-cache-for-accept_atte.patch.license
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
  ## Summary

  Replace sidecar license files with root-level `REUSE.toml` annotations.

  This adds REUSE coverage for:
  - `flake.lock`
  - `docs/*.pdf`
  - `docs/pygments.theme`
  - `packages/keylime/*.patch`
  - `packages/keylime-agent/*.patch`

  With those paths covered by `REUSE.toml`, the corresponding `.license` sidecar files are removed.

  ## Why

  `flake.lock`, PDFs, theme data, and patch files are better handled through `REUSE.toml` than per-file sidecars. This keeps
  the repository closer to REUSE best practices while reducing clutter.

  ## Testing

  - Reviewed `REUSE.toml` coverage against the existing sidecar-managed files
  - Verified there are no remaining `*.license` sidecar files in the repo
  - `reuse lint`: Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
 
